### PR TITLE
ci(docs): publish typedoc to pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: docs
+on:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm ci
+      - run: npm run docgen
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: docs
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,4 +17,5 @@ jobs:
         with:
           publish: npm run build && npm run release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/API.md
+++ b/API.md
@@ -1,4 +1,4 @@
-@dmoove/cdk-gitlab-runner / [Exports](modules.md)
+@dmoove/cdk-gitlab-runner / [Exports](docs/modules.md)
 
 # @yanu23/cdk-gitlab-runner
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "pre-compile": "esbuild --bundle --external:aws-sdk --platform=node src/drain-runner/lambda/drain.function.ts --outfile=lambda/index.js && esbuild --bundle --external:aws-sdk --platform=node src/pending-metric/lambda/pending-jobs.function.ts --outfile=lambda/pending-jobs.js",
     "compile": "tsc -p tsconfig.json",
-    "docgen": "typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts && cp docs/README.md API.md && rimraf docs",
+    "docgen": "typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts && sed 's](modules.md)](docs/modules.md)]' docs/README.md > API.md",
     "docs": "typedoc --plugin typedoc-plugin-markdown --out docs src/index.ts",
     "lint": "eslint --ext .ts src test",
     "lint:fix": "eslint --ext .ts src test --fix",


### PR DESCRIPTION
## Summary
- publish TypeDoc output via GitHub Pages
- keep generated docs and link them from API.md
- fix release workflow to provide the GitHub token

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68455a9899408321a24be00e1fbb96d2